### PR TITLE
Fix Netty DNS warning on macOS

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,15 +6,15 @@ module(
 bazel_dep(name = "rules_jvm_external", version = "6.2")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
-
 maven.install(
     name = "maven",
     artifacts = [
         "io.vertx:vertx-core:4.5.1",
+        # Include MacOS native DNS resolver to avoid runtime warnings on Mac
+        "io.netty:netty-resolver-dns-native-macos:4.1.103.Final:osx-aarch_64",
     ],
     repositories = [
         "https://repo.maven.apache.org/maven2",
     ],
 )
-
 use_repo(maven, "maven")

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Este es un proyecto base de Java usando [Vert.x](https://vertx.io/) y [Bazel](https://bazel.build/).
 
+Incluye la dependencia `netty-resolver-dns-native-macos` para evitar la advertencia
+de Netty en macOS sobre la resolución DNS.
+
 ## Ejecutar
 
 ```


### PR DESCRIPTION
## Summary
- add `netty-resolver-dns-native-macos` dependency for macOS
- note the new dependency in the README

## Testing
- `bazel build //:vertx_hello` *(fails: The current user is root, please run as non-root when using the hermetic Python interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_68468f79cd788323b34ad9f2103d176b