### PR TITLE
Add Bonoloto data downloader

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,3 +6,12 @@ java_binary(
         "@maven//:io_vertx_vertx_core",
     ],
 )
+
+java_binary(
+    name = "bonoloto_downloader",
+    srcs = glob(["src/main/java/**/*.java"]),
+    main_class = "com.csoft.BonolotoDataDownloader",
+    deps = [
+        "@maven//:io_vertx_vertx_core",
+    ],
+)

--- a/src/main/java/com/csoft/BonolotoDataDownloader.java
+++ b/src/main/java/com/csoft/BonolotoDataDownloader.java
@@ -1,0 +1,58 @@
+package com.csoft;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to download the historical Bonoloto results CSV and remove
+ * malformed lines.
+ */
+public class BonolotoDataDownloader {
+    private static final String DATA_URL =
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vQALTRaLDFfhXOAQmeONPqmFKm9yOiQ4W97rhWgR41BZ7czFsjK5YktD6fnETKHGB9YUnyQ4XBSbhZx/pub?gid=0&single=true&output=csv";
+
+    /**
+     * Downloads the CSV, removes lines that don't have exactly nine columns and
+     * writes the cleaned content to the provided path.
+     */
+    public static void downloadAndClean(Path outputPath) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(DATA_URL)).build();
+        HttpResponse<java.io.InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+        List<String> validLines = new ArrayList<>();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] parts = line.split(",", -1);
+                if (parts.length == 9) {
+                    validLines.add(line);
+                }
+            }
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            for (String l : validLines) {
+                writer.write(l);
+                writer.newLine();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Path out = Path.of(args.length > 0 ? args[0] : "bonoloto_clean.csv");
+        downloadAndClean(out);
+        System.out.println("Datos guardados en " + out.toAbsolutePath());
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple Java utility to download and clean the Bonoloto CSV
- expose a new Bazel target `bonoloto_downloader`

## Testing
- `bazel build //:bonoloto_downloader` *(fails: hermetic Python cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68469ac75834832391cd24046cccc7b4