### PR TITLE
Add Vue-based UI and update server endpoints

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,11 @@
 java_binary(
     name = "vertx_hello",
     srcs = glob(["src/main/java/**/*.java"]),
+    resources = glob(["src/main/resources/**"]),
     main_class = "com.csoft.MainVerticle",
     deps = [
         "@maven//:io_vertx_vertx_core",
+        "@maven//:io_vertx_vertx_web",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ maven.install(
     name = "maven",
     artifacts = [
         "io.vertx:vertx-core:4.5.1",
+        "io.vertx:vertx-web:4.5.1",
         # Include MacOS native DNS resolver to avoid runtime warnings on Mac
         "io.netty:netty-resolver-dns-native-macos:4.1.103.Final:osx-aarch_64",
     ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # csoft
 
 Este es un proyecto base de Java usando [Vert.x](https://vertx.io/) y [Bazel](https://bazel.build/).
+Incluye una pequeña interfaz web desarrollada con Vue.js para descargar y
+consultar el histórico de sorteos de la Bonoloto.
 
 Incluye la dependencia `netty-resolver-dns-native-macos` para evitar la advertencia
 de Netty en macOS sobre la resolución DNS.
@@ -11,4 +13,7 @@ de Netty en macOS sobre la resolución DNS.
 bazel run //:vertx_hello
 ```
 
-Al ejecutarlo, se inicia un servidor HTTP en el puerto `8080` que responde con `Hola Mundo`.
+Al ejecutarlo, se inicia un servidor HTTP en el puerto `8080` que sirve la página
+web Vue.js disponible en [http://localhost:8080](http://localhost:8080). Desde
+la página principal puedes actualizar el histórico de sorteos y consultar los
+resultados descargados.

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -2,12 +2,47 @@ package com.csoft;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.StaticHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.csoft.BonolotoDataDownloader;
 
 public class MainVerticle extends AbstractVerticle {
     @Override
     public void start() {
+        Router router = Router.router(vertx);
+
+        router.get("/api/update").handler(ctx -> {
+            try {
+                Path out = Path.of("webroot/history.csv");
+                BonolotoDataDownloader.downloadAndClean(out);
+                ctx.response().putHeader("Content-Type", "application/json")
+                    .end("{\"status\":\"ok\"}");
+            } catch (Exception e) {
+                ctx.fail(e);
+            }
+        });
+
+        router.get("/api/history").handler(ctx -> {
+            try {
+                Path path = Path.of("webroot/history.csv");
+                if (!Files.exists(path)) {
+                    ctx.response().setStatusCode(404).end();
+                    return;
+                }
+                String csv = Files.readString(path);
+                ctx.response().putHeader("Content-Type", "text/csv").end(csv);
+            } catch (Exception e) {
+                ctx.fail(e);
+            }
+        });
+
+        router.route().handler(StaticHandler.create("webroot"));
+
         vertx.createHttpServer()
-            .requestHandler(req -> req.response().end("Hola Mundo"))
+            .requestHandler(router)
             .listen(8080);
     }
 

--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Bonoloto</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+  <script src="https://unpkg.com/vue-router@4"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    const Home = {
+      template: `
+        <div>
+          <h1>Bonoloto</h1>
+          <button @click="update">Actualizar histórico</button>
+          <router-link to="/history"><button>Consultar histórico</button></router-link>
+        </div>
+      `,
+      methods: {
+        async update() {
+          try {
+            await fetch('/api/update');
+            alert('Actualizado');
+          } catch (e) {
+            alert('Error al actualizar');
+          }
+        }
+      }
+    };
+
+    const History = {
+      data() { return { rows: [] }; },
+      async created() {
+        const res = await fetch('/api/history');
+        const text = await res.text();
+        this.rows = text.trim().split('\n').map(l => l.split(','));
+      },
+      template: `
+        <div>
+          <h1>Histórico</h1>
+          <router-link to="/">Volver</router-link>
+          <table border="1">
+            <tr v-for="row in rows" :key="row[0]">
+              <td v-for="cell in row">{{ cell }}</td>
+            </tr>
+          </table>
+        </div>
+      `
+    };
+
+    const routes = [
+      { path: '/', component: Home },
+      { path: '/history', component: History }
+    ];
+
+    const router = VueRouter.createRouter({
+      history: VueRouter.createWebHashHistory(),
+      routes
+    });
+
+    const app = Vue.createApp({});
+    app.use(router);
+    app.mount('#app');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Vue.js single page app with navigation for updating and viewing draw history
- serve static files and history through new API routes
- include vertx-web dependency and web resources in build config
- document running the updated server

## Testing
- `bazel build //:vertx_hello` *(fails: The current user is root)*

------
https://chatgpt.com/codex/tasks/task_e_68469d136cec83239a9495c4813ab165