### PR TITLE
Fix Bazel run under root

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "rules_jvm_external", version = "6.2")
+bazel_dep(name = "rules_python", version = "0.40.0")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
@@ -12,10 +13,18 @@ maven.install(
         "io.vertx:vertx-core:4.5.1",
         "io.vertx:vertx-web:4.5.1",
         # Include MacOS native DNS resolver to avoid runtime warnings on Mac
-        "io.netty:netty-resolver-dns-native-macos:4.1.103.Final:osx-aarch_64",
+        "io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.103.Final",
     ],
     repositories = [
         "https://repo.maven.apache.org/maven2",
     ],
 )
 use_repo(maven, "maven")
+
+python_ext = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python_ext.toolchain(
+    python_version = "3.11",
+    is_default = True,
+    ignore_root_user_error = True,
+)
+use_repo(python_ext, "python_3_11")


### PR DESCRIPTION
## Summary
- add rules_python and default python toolchain
- fix netty native artifact coordinates
- register python toolchain with ignore_root_user_error

## Testing
- `bazel build //:vertx_hello`

------
https://chatgpt.com/codex/tasks/task_e_68469f09c6d08323991cc2222be1beaa