### PR TITLE
Fix Vue router mount

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -82,7 +82,9 @@
       routes
     });
 
-    const app = Vue.createApp({});
+    const app = Vue.createApp({
+      template: '<router-view></router-view>'
+    });
     app.use(router);
     app.mount('#app');
   </script>


### PR DESCRIPTION
## Summary
- render router in index.html so Vue no longer warns about missing template

## Testing
- `bazel build //:vertx_hello`

------
https://chatgpt.com/codex/tasks/task_e_6846a9aebbac8323a1b28d066b697708