### PR TITLE
Fix history update path creation

### DIFF
--- a/src/main/java/com/csoft/BonolotoDataDownloader.java
+++ b/src/main/java/com/csoft/BonolotoDataDownloader.java
@@ -42,6 +42,7 @@ public class BonolotoDataDownloader {
             }
         }
 
+        Files.createDirectories(outputPath.getParent());
         try (BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
             for (String l : validLines) {
                 writer.write(l);


### PR DESCRIPTION
## Summary
- ensure Bonoloto CSV updater creates the webroot directory before writing

## Testing
- `bazel build //:vertx_hello`

------
https://chatgpt.com/codex/tasks/task_e_6846ac49b4bc8323a7d88d23fbde9440