### PR TITLE
Fix history saving path and add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bazel-*
 server.log
 *.log
+data/

--- a/BUILD
+++ b/BUILD
@@ -11,7 +11,7 @@ java_binary(
 
 java_binary(
     name = "bonoloto_downloader",
-    srcs = glob(["src/main/java/**/*.java"]),
+    srcs = ["src/main/java/com/csoft/BonolotoDataDownloader.java"],
     main_class = "com.csoft.BonolotoDataDownloader",
     deps = [
         "@maven//:io_vertx_vertx_core",

--- a/src/main/java/com/csoft/BonolotoDataDownloader.java
+++ b/src/main/java/com/csoft/BonolotoDataDownloader.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Utility class to download the historical Bonoloto results CSV and remove
@@ -21,12 +22,14 @@ import java.util.List;
 public class BonolotoDataDownloader {
     private static final String DATA_URL =
         "https://docs.google.com/spreadsheets/d/e/2PACX-1vQALTRaLDFfhXOAQmeONPqmFKm9yOiQ4W97rhWgR41BZ7czFsjK5YktD6fnETKHGB9YUnyQ4XBSbhZx/pub?gid=0&single=true&output=csv";
+    private static final Logger LOGGER = Logger.getLogger(BonolotoDataDownloader.class.getName());
 
     /**
      * Downloads the CSV, removes lines that don't have exactly nine columns and
      * writes the cleaned content to the provided path.
      */
     public static void downloadAndClean(Path outputPath) throws IOException, InterruptedException {
+        LOGGER.info("Descargando datos desde " + DATA_URL);
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder(URI.create(DATA_URL)).build();
         HttpResponse<java.io.InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
@@ -49,6 +52,7 @@ public class BonolotoDataDownloader {
                 writer.newLine();
             }
         }
+        LOGGER.info("Datos guardados en " + outputPath.toAbsolutePath());
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -6,18 +6,22 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.StaticHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.logging.Logger;
 
 import com.csoft.BonolotoDataDownloader;
 
 public class MainVerticle extends AbstractVerticle {
+    private static final Logger LOGGER = Logger.getLogger(MainVerticle.class.getName());
     @Override
     public void start() {
         Router router = Router.router(vertx);
 
         router.get("/api/update").handler(ctx -> {
             try {
-                Path out = Path.of("webroot/history.csv");
+                Path out = Path.of("data/history.csv");
+                LOGGER.info("Actualizando historico");
                 BonolotoDataDownloader.downloadAndClean(out);
+                LOGGER.info("Actualizacion finalizada");
                 ctx.response().putHeader("Content-Type", "application/json")
                     .end("{\"status\":\"ok\"}");
             } catch (Exception e) {
@@ -27,11 +31,12 @@ public class MainVerticle extends AbstractVerticle {
 
         router.get("/api/history").handler(ctx -> {
             try {
-                Path path = Path.of("webroot/history.csv");
+                Path path = Path.of("data/history.csv");
                 if (!Files.exists(path)) {
                     ctx.response().setStatusCode(404).end();
                     return;
                 }
+                LOGGER.info("Sirviendo historico");
                 String csv = Files.readString(path);
                 ctx.response().putHeader("Content-Type", "text/csv").end(csv);
             } catch (Exception e) {


### PR DESCRIPTION
## Summary
- store historical CSV in a writable `data/` folder
- ignore generated data
- add logging messages
- narrow source set of `bonoloto_downloader` binary

## Testing
- `bazel build //:vertx_hello`
- `bazel build //:bonoloto_downloader`


------
https://chatgpt.com/codex/tasks/task_e_6846b17c251c8323a7e4482ddb260c40