### PR TITLE
Improve download logging

### DIFF
--- a/src/main/java/com/csoft/BonolotoDataDownloader.java
+++ b/src/main/java/com/csoft/BonolotoDataDownloader.java
@@ -34,16 +34,24 @@ public class BonolotoDataDownloader {
         HttpRequest request = HttpRequest.newBuilder(URI.create(DATA_URL)).build();
         HttpResponse<java.io.InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
+        LOGGER.info("Codigo de respuesta: " + response.statusCode());
+
+        byte[] allBytes = response.body().readAllBytes();
+        LOGGER.info("Descargados " + allBytes.length + " bytes");
+
         List<String> validLines = new ArrayList<>();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))) {
+        int totalLines = 0;
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new java.io.ByteArrayInputStream(allBytes), StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
+                totalLines++;
                 String[] parts = line.split(",", -1);
                 if (parts.length == 9) {
                     validLines.add(line);
                 }
             }
         }
+        LOGGER.info("Lineas totales: " + totalLines + ", lineas validas: " + validLines.size());
 
         Files.createDirectories(outputPath.getParent());
         try (BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -19,9 +19,10 @@ public class MainVerticle extends AbstractVerticle {
         router.get("/api/update").handler(ctx -> {
             try {
                 Path out = Path.of("data/history.csv");
-                LOGGER.info("Actualizando historico");
+                LOGGER.info("Actualizando historico en " + out.toAbsolutePath());
                 BonolotoDataDownloader.downloadAndClean(out);
-                LOGGER.info("Actualizacion finalizada");
+                long size = Files.size(out);
+                LOGGER.info("Actualizacion finalizada. Tama\u00f1o del fichero: " + size + " bytes");
                 ctx.response().putHeader("Content-Type", "application/json")
                     .end("{\"status\":\"ok\"}");
             } catch (Exception e) {
@@ -36,7 +37,8 @@ public class MainVerticle extends AbstractVerticle {
                     ctx.response().setStatusCode(404).end();
                     return;
                 }
-                LOGGER.info("Sirviendo historico");
+                long size = Files.size(path);
+                LOGGER.info("Sirviendo historico desde " + path.toAbsolutePath() + " (" + size + " bytes)");
                 String csv = Files.readString(path);
                 ctx.response().putHeader("Content-Type", "text/csv").end(csv);
             } catch (Exception e) {


### PR DESCRIPTION
## Summary
- add detailed logs about download response code, byte count, and line filtering
- log file size when updating and serving history

## Testing
- `bazel build //:vertx_hello`

------
https://chatgpt.com/codex/tasks/task_e_6846b454478c8323a389293c7e0ad1b5