### PR TITLE
Handle redirects in Bonoloto downloader

### DIFF
--- a/src/main/java/com/csoft/BonolotoDataDownloader.java
+++ b/src/main/java/com/csoft/BonolotoDataDownloader.java
@@ -30,7 +30,9 @@ public class BonolotoDataDownloader {
      */
     public static void downloadAndClean(Path outputPath) throws IOException, InterruptedException {
         LOGGER.info("Descargando datos desde " + DATA_URL);
-        HttpClient client = HttpClient.newHttpClient();
+        HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .build();
         HttpRequest request = HttpRequest.newBuilder(URI.create(DATA_URL)).build();
         HttpResponse<java.io.InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
 


### PR DESCRIPTION
## Summary
- configure `HttpClient` to follow redirects when downloading the Bonoloto CSV

## Testing
- `bazel build //:bonoloto_downloader`
- `bazel build //:vertx_hello`


------
https://chatgpt.com/codex/tasks/task_e_6846ba8911b08323b8d9fa6142e85447