### PR TITLE
Add stats tool for even/odd numbers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,3 +17,9 @@ java_binary(
         "@maven//:io_vertx_vertx_core",
     ],
 )
+
+java_binary(
+    name = "bonoloto_stats",
+    srcs = ["src/main/java/com/csoft/BonolotoStats.java"],
+    main_class = "com.csoft.BonolotoStats",
+)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ Al ejecutarlo, se inicia un servidor HTTP en el puerto `8080` que sirve la pági
 web Vue.js disponible en [http://localhost:8080](http://localhost:8080). Desde
 la página principal puedes actualizar el histórico de sorteos y consultar los
 resultados descargados.
+
+## Obtener estadísticas de pares e impares
+
+Puedes calcular cuántos números pares e impares aparecieron en cada sorteo usando el binario `bonoloto_stats`:
+
+```
+bazel run //:bonoloto_stats -- path/al/fichero.csv
+```
+
+La salida es un CSV con las columnas `FECHA`, `EVEN` e `ODD` indicando la cantidad de números pares e impares en los seis números de cada combinación ganadora.
+

--- a/src/main/java/com/csoft/BonolotoStats.java
+++ b/src/main/java/com/csoft/BonolotoStats.java
@@ -1,0 +1,56 @@
+package com.csoft;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BonolotoStats {
+    public static class DrawStat {
+        public final String date;
+        public final int even;
+        public final int odd;
+        public DrawStat(String date, int even, int odd) {
+            this.date = date;
+            this.even = even;
+            this.odd = odd;
+        }
+    }
+
+    public static List<DrawStat> compute(Path csv) throws IOException {
+        List<DrawStat> list = new ArrayList<>();
+        try (BufferedReader br = Files.newBufferedReader(csv, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] parts = line.split(",", -1);
+                if (parts.length != 9 || parts[0].equalsIgnoreCase("FECHA")) {
+                    continue;
+                }
+                int even = 0;
+                int odd = 0;
+                for (int i = 1; i <= 6; i++) {
+                    int n = Integer.parseInt(parts[i]);
+                    if (n % 2 == 0) {
+                        even++;
+                    } else {
+                        odd++;
+                    }
+                }
+                list.add(new DrawStat(parts[0], even, odd));
+            }
+        }
+        return list;
+    }
+
+    public static void main(String[] args) throws Exception {
+        Path path = Path.of(args.length > 0 ? args[0] : "data/history.csv");
+        List<DrawStat> stats = compute(path);
+        System.out.println("FECHA,EVEN,ODD");
+        for (DrawStat s : stats) {
+            System.out.println(s.date + "," + s.even + "," + s.odd);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `BonolotoStats` utility to count even and odd numbers per draw
- expose new `bonoloto_stats` target in BUILD
- document how to run the stats tool

## Testing
- `bazel build //...`
- `bazel run :bonoloto_stats -- $(pwd)/data/history.csv | head`
- `bazel build :vertx_hello`


------
https://chatgpt.com/codex/tasks/task_e_6847f42efb148323911827294ffaabdf