### PR TITLE
Add stats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ bazel run //:vertx_hello
 Al ejecutarlo, se inicia un servidor HTTP en el puerto `8080` que sirve la página
 web Vue.js disponible en [http://localhost:8080](http://localhost:8080). Desde
 la página principal puedes actualizar el histórico de sorteos y consultar los
-resultados descargados.
+resultados descargados. Ahora también puedes consultar las estadísticas de pares
+e impares desde el enlace **Estadísticas** de la propia interfaz.
 
 ## Obtener estadísticas de pares e impares
 

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 
 import com.csoft.BonolotoDataDownloader;
+import com.csoft.BonolotoStats;
 
 public class MainVerticle extends AbstractVerticle {
     private static final Logger LOGGER = Logger.getLogger(MainVerticle.class.getName());
@@ -41,6 +42,25 @@ public class MainVerticle extends AbstractVerticle {
                 LOGGER.info("Sirviendo historico desde " + path.toAbsolutePath() + " (" + size + " bytes)");
                 String csv = Files.readString(path);
                 ctx.response().putHeader("Content-Type", "text/csv").end(csv);
+            } catch (Exception e) {
+                ctx.fail(e);
+            }
+        });
+
+        router.get("/api/stats").handler(ctx -> {
+            try {
+                Path path = Path.of("data/history.csv");
+                if (!Files.exists(path)) {
+                    ctx.response().setStatusCode(404).end();
+                    return;
+                }
+                var stats = BonolotoStats.compute(path);
+                StringBuilder sb = new StringBuilder();
+                sb.append("FECHA,EVEN,ODD\n");
+                for (var s : stats) {
+                    sb.append(s.date).append(',').append(s.even).append(',').append(s.odd).append('\n');
+                }
+                ctx.response().putHeader("Content-Type", "text/csv").end(sb.toString());
             } catch (Exception e) {
                 ctx.fail(e);
             }

--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -20,6 +20,9 @@
           <li class="nav-item">
             <router-link class="nav-link" to="/history">Histórico</router-link>
           </li>
+          <li class="nav-item">
+            <router-link class="nav-link" to="/stats">Estadísticas</router-link>
+          </li>
         </ul>
       </div>
     </div>
@@ -33,6 +36,7 @@
           <div class="d-grid gap-2 col-6 mx-auto">
             <button class="btn btn-primary" @click="update">Actualizar histórico</button>
             <router-link to="/history" class="btn btn-secondary">Ver histórico</router-link>
+            <router-link to="/stats" class="btn btn-secondary">Estadísticas</router-link>
           </div>
         </div>
       `,
@@ -72,9 +76,34 @@
       `
     };
 
+  const Stats = {
+      data() { return { rows: [] }; },
+      async created() {
+        const res = await fetch('/api/stats');
+        const text = await res.text();
+        this.rows = text.trim().split('\n').map(l => l.split(','));
+      },
+      template: `
+        <div>
+          <h1>Estadísticas Pares/Impares</h1>
+          <router-link to="/" class="btn btn-link p-0 mb-3">Volver</router-link>
+          <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+              <tbody>
+                <tr v-for="row in rows" :key="row[0]">
+                  <td v-for="cell in row">{{ cell }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      `
+    };
+
     const routes = [
       { path: '/', component: Home },
-      { path: '/history', component: History }
+      { path: '/history', component: History },
+      { path: '/stats', component: Stats }
     ];
 
     const router = VueRouter.createRouter({


### PR DESCRIPTION
## Summary
- add `/api/stats` endpoint to return pair/odd counts
- show new "Estadísticas" option in navigation and home page
- add new Stats component in the frontend
- document stats page in README

## Testing
- `bazel build //:vertx_hello`


------
https://chatgpt.com/codex/tasks/task_e_6847f72502148323ac585cf7f162523b