### PR TITLE
Add decenas & consecutive stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ bazel run //:vertx_hello
 Al ejecutarlo, se inicia un servidor HTTP en el puerto `8080` que sirve la página
 web Vue.js disponible en [http://localhost:8080](http://localhost:8080). Desde
 la página principal puedes actualizar el histórico de sorteos y consultar los
-resultados descargados. Ahora también puedes consultar las estadísticas de pares
-e impares desde el enlace **Estadísticas** de la propia interfaz.
+resultados descargados. Ahora también puedes consultar distintas estadísticas
+desde el enlace **Estadísticas** de la propia interfaz.
 
-## Obtener estadísticas de pares e impares
+## Obtener estadísticas
 
-Puedes calcular cuántos números pares e impares aparecieron en cada sorteo usando el binario `bonoloto_stats`:
+Puedes calcular las estadísticas (pares/impares, reparto por decenas y rachas de números consecutivos) usando el binario `bonoloto_stats`:
 
 ```
 bazel run //:bonoloto_stats -- path/al/fichero.csv
 ```
 
-La salida es un CSV con las columnas `FECHA`, `EVEN` e `ODD` indicando la cantidad de números pares e impares en los seis números de cada combinación ganadora.
+La salida es un CSV con las columnas `FECHA`, `EVEN`, `ODD`, `D1`-`D5` (números en las decenas 1‑9, 10‑19, 20‑29, 30‑39 y 40‑49) y `CONSEC`, la longitud máxima de números consecutivos en la combinación.
 

--- a/src/main/java/com/csoft/BonolotoStats.java
+++ b/src/main/java/com/csoft/BonolotoStats.java
@@ -13,10 +13,15 @@ public class BonolotoStats {
         public final String date;
         public final int even;
         public final int odd;
-        public DrawStat(String date, int even, int odd) {
+        public final int[] tens; // counts of numbers in each tens range
+        public final int consecutive; // longest streak of consecutive numbers
+
+        public DrawStat(String date, int even, int odd, int[] tens, int consecutive) {
             this.date = date;
             this.even = even;
             this.odd = odd;
+            this.tens = tens;
+            this.consecutive = consecutive;
         }
     }
 
@@ -31,15 +36,43 @@ public class BonolotoStats {
                 }
                 int even = 0;
                 int odd = 0;
+                int[] tens = new int[5];
+                int[] numbers = new int[6];
                 for (int i = 1; i <= 6; i++) {
                     int n = Integer.parseInt(parts[i]);
+                    numbers[i - 1] = n;
                     if (n % 2 == 0) {
                         even++;
                     } else {
                         odd++;
                     }
+                    if (n <= 9) {
+                        tens[0]++;
+                    } else if (n <= 19) {
+                        tens[1]++;
+                    } else if (n <= 29) {
+                        tens[2]++;
+                    } else if (n <= 39) {
+                        tens[3]++;
+                    } else {
+                        tens[4]++;
+                    }
                 }
-                list.add(new DrawStat(parts[0], even, odd));
+
+                int maxRun = 1;
+                int currentRun = 1;
+                for (int i = 1; i < numbers.length; i++) {
+                    if (numbers[i] == numbers[i - 1] + 1) {
+                        currentRun++;
+                        if (currentRun > maxRun) {
+                            maxRun = currentRun;
+                        }
+                    } else {
+                        currentRun = 1;
+                    }
+                }
+
+                list.add(new DrawStat(parts[0], even, odd, tens, maxRun));
             }
         }
         return list;
@@ -48,9 +81,11 @@ public class BonolotoStats {
     public static void main(String[] args) throws Exception {
         Path path = Path.of(args.length > 0 ? args[0] : "data/history.csv");
         List<DrawStat> stats = compute(path);
-        System.out.println("FECHA,EVEN,ODD");
+        System.out.println("FECHA,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC");
         for (DrawStat s : stats) {
-            System.out.println(s.date + "," + s.even + "," + s.odd);
+            System.out.println(s.date + "," + s.even + "," + s.odd + "," +
+                    s.tens[0] + "," + s.tens[1] + "," + s.tens[2] + "," +
+                    s.tens[3] + "," + s.tens[4] + "," + s.consecutive);
         }
     }
 }

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -56,9 +56,13 @@ public class MainVerticle extends AbstractVerticle {
                 }
                 var stats = BonolotoStats.compute(path);
                 StringBuilder sb = new StringBuilder();
-                sb.append("FECHA,EVEN,ODD\n");
+                sb.append("FECHA,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC\n");
                 for (var s : stats) {
-                    sb.append(s.date).append(',').append(s.even).append(',').append(s.odd).append('\n');
+                    sb.append(s.date).append(',').append(s.even).append(',').append(s.odd)
+                      .append(',').append(s.tens[0]).append(',').append(s.tens[1])
+                      .append(',').append(s.tens[2]).append(',').append(s.tens[3])
+                      .append(',').append(s.tens[4]).append(',').append(s.consecutive)
+                      .append('\n');
                 }
                 ctx.response().putHeader("Content-Type", "text/csv").end(sb.toString());
             } catch (Exception e) {

--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -85,7 +85,7 @@
       },
       template: `
         <div>
-          <h1>Estadísticas Pares/Impares</h1>
+          <h1>Estadísticas</h1>
           <router-link to="/" class="btn btn-link p-0 mb-3">Volver</router-link>
           <div class="table-responsive">
             <table class="table table-striped table-bordered">


### PR DESCRIPTION
## Summary
- compute counts per tens range and longest sequence of consecutive numbers
- expose new stats via API and CLI
- update web frontend to show generic statistics
- refresh README with new CSV format

## Testing
- `bazel build //:bonoloto_stats`
- `bazel build //:vertx_hello`
- `./bazel-bin/bonoloto_stats history.csv | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_6847fd0ef4bc832382decd0466c55452