### PR TITLE
Add winning combination to stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Puedes calcular las estadísticas (pares/impares, reparto por decenas y rachas d
 bazel run //:bonoloto_stats -- path/al/fichero.csv
 ```
 
-La salida es un CSV con las columnas `FECHA`, `EVEN`, `ODD`, `D1`-`D5` (números en las decenas 1‑9, 10‑19, 20‑29, 30‑39 y 40‑49) y `CONSEC`, la longitud máxima de números consecutivos en la combinación.
+La salida es un CSV con las columnas `FECHA`, `N1`-`N6` (números de la combinación ganadora), `EVEN`, `ODD`, `D1`-`D5` (números en las decenas 1‑9, 10‑19, 20‑29, 30‑39 y 40‑49) y `CONSEC`, la longitud máxima de números consecutivos en la combinación.
 

--- a/src/main/java/com/csoft/BonolotoStats.java
+++ b/src/main/java/com/csoft/BonolotoStats.java
@@ -11,13 +11,16 @@ import java.util.List;
 public class BonolotoStats {
     public static class DrawStat {
         public final String date;
+        /** Winning combination numbers */
+        public final int[] numbers;
         public final int even;
         public final int odd;
         public final int[] tens; // counts of numbers in each tens range
         public final int consecutive; // longest streak of consecutive numbers
 
-        public DrawStat(String date, int even, int odd, int[] tens, int consecutive) {
+        public DrawStat(String date, int[] numbers, int even, int odd, int[] tens, int consecutive) {
             this.date = date;
+            this.numbers = numbers;
             this.even = even;
             this.odd = odd;
             this.tens = tens;
@@ -72,7 +75,7 @@ public class BonolotoStats {
                     }
                 }
 
-                list.add(new DrawStat(parts[0], even, odd, tens, maxRun));
+                list.add(new DrawStat(parts[0], numbers, even, odd, tens, maxRun));
             }
         }
         return list;
@@ -81,11 +84,18 @@ public class BonolotoStats {
     public static void main(String[] args) throws Exception {
         Path path = Path.of(args.length > 0 ? args[0] : "data/history.csv");
         List<DrawStat> stats = compute(path);
-        System.out.println("FECHA,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC");
+        System.out.println("FECHA,N1,N2,N3,N4,N5,N6,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC");
         for (DrawStat s : stats) {
-            System.out.println(s.date + "," + s.even + "," + s.odd + "," +
-                    s.tens[0] + "," + s.tens[1] + "," + s.tens[2] + "," +
-                    s.tens[3] + "," + s.tens[4] + "," + s.consecutive);
+            StringBuilder sb = new StringBuilder();
+            sb.append(s.date);
+            for (int n : s.numbers) {
+                sb.append(',').append(n);
+            }
+            sb.append(',').append(s.even).append(',').append(s.odd)
+              .append(',').append(s.tens[0]).append(',').append(s.tens[1])
+              .append(',').append(s.tens[2]).append(',').append(s.tens[3])
+              .append(',').append(s.tens[4]).append(',').append(s.consecutive);
+            System.out.println(sb);
         }
     }
 }

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -56,9 +56,13 @@ public class MainVerticle extends AbstractVerticle {
                 }
                 var stats = BonolotoStats.compute(path);
                 StringBuilder sb = new StringBuilder();
-                sb.append("FECHA,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC\n");
+                sb.append("FECHA,N1,N2,N3,N4,N5,N6,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC\n");
                 for (var s : stats) {
-                    sb.append(s.date).append(',').append(s.even).append(',').append(s.odd)
+                    sb.append(s.date);
+                    for (int n : s.numbers) {
+                        sb.append(',').append(n);
+                    }
+                    sb.append(',').append(s.even).append(',').append(s.odd)
                       .append(',').append(s.tens[0]).append(',').append(s.tens[1])
                       .append(',').append(s.tens[2]).append(',').append(s.tens[3])
                       .append(',').append(s.tens[4]).append(',').append(s.consecutive)


### PR DESCRIPTION
## Summary
- include the six winning numbers in `BonolotoStats.DrawStat`
- output the combination in CLI and API stats
- document new CSV columns in README

## Testing
- `bazel build //...` *(fails: environment constraints prevent dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684800ab383c83238f6cf348676d39f4