### PR TITLE
Fix streak of consecutive numbers

### DIFF
--- a/src/main/java/com/csoft/BonolotoStats.java
+++ b/src/main/java/com/csoft/BonolotoStats.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class BonolotoStats {
@@ -61,6 +62,8 @@ public class BonolotoStats {
                         tens[4]++;
                     }
                 }
+
+                Arrays.sort(numbers);
 
                 int maxRun = 1;
                 int currentRun = 1;


### PR DESCRIPTION
## Summary
- ensure numbers are sorted before evaluating consecutive runs

## Testing
- `bazel build //:bonoloto_stats`
- `bazel test //...` *(fails: no test targets were found)*

------
https://chatgpt.com/codex/tasks/task_e_68480a4ddce08323af4b78261266604a