### PR TITLE
Add pagination navigation to web UI

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -57,7 +57,8 @@
         return { rows: [], page: 1, pageSize: 20, total: 0 };
       },
       computed: {
-        totalPages() { return Math.ceil(this.total / this.pageSize); }
+        totalPages() { return Math.ceil(this.total / this.pageSize); },
+        pages() { return Array.from({length: this.totalPages}, (_, i) => i + 1); }
       },
       methods: {
         async load() {
@@ -67,7 +68,8 @@
           this.rows = text.trim().split('\n').map(l => l.split(','));
         },
         next() { if (this.page < this.totalPages) { this.page++; this.load(); } },
-        prev() { if (this.page > 1) { this.page--; this.load(); } }
+        prev() { if (this.page > 1) { this.page--; this.load(); } },
+        go(p) { if (p !== this.page && p >= 1 && p <= this.totalPages) { this.page = p; this.load(); } }
       },
       async created() { await this.load(); },
       template: `
@@ -83,11 +85,19 @@
               </tbody>
             </table>
           </div>
-          <div class="d-flex justify-content-between">
-            <button class="btn btn-secondary" @click="prev" :disabled="page===1">Anterior</button>
-            <span>Página {{ page }} de {{ totalPages }}</span>
-            <button class="btn btn-secondary" @click="next" :disabled="page===totalPages">Siguiente</button>
-          </div>
+          <nav aria-label="Histórico navigation">
+            <ul class="pagination justify-content-center mb-0">
+              <li class="page-item" :class="{disabled: page===1}">
+                <button class="page-link" @click="prev">Anterior</button>
+              </li>
+              <li class="page-item" v-for="p in pages" :key="p" :class="{active: p===page}">
+                <button class="page-link" @click="go(p)">{{ p }}</button>
+              </li>
+              <li class="page-item" :class="{disabled: page===totalPages}">
+                <button class="page-link" @click="next">Siguiente</button>
+              </li>
+            </ul>
+          </nav>
         </div>
       `
     };
@@ -97,7 +107,8 @@
         return { rows: [], page: 1, pageSize: 20, total: 0 };
       },
       computed: {
-        totalPages() { return Math.ceil(this.total / this.pageSize); }
+        totalPages() { return Math.ceil(this.total / this.pageSize); },
+        pages() { return Array.from({length: this.totalPages}, (_, i) => i + 1); }
       },
       methods: {
         async load() {
@@ -107,7 +118,8 @@
           this.rows = text.trim().split('\n').map(l => l.split(','));
         },
         next() { if (this.page < this.totalPages) { this.page++; this.load(); } },
-        prev() { if (this.page > 1) { this.page--; this.load(); } }
+        prev() { if (this.page > 1) { this.page--; this.load(); } },
+        go(p) { if (p !== this.page && p >= 1 && p <= this.totalPages) { this.page = p; this.load(); } }
       },
       async created() { await this.load(); },
       template: `
@@ -123,11 +135,19 @@
               </tbody>
             </table>
           </div>
-          <div class="d-flex justify-content-between">
-            <button class="btn btn-secondary" @click="prev" :disabled="page===1">Anterior</button>
-            <span>Página {{ page }} de {{ totalPages }}</span>
-            <button class="btn btn-secondary" @click="next" :disabled="page===totalPages">Siguiente</button>
-          </div>
+          <nav aria-label="Estadísticas navigation">
+            <ul class="pagination justify-content-center mb-0">
+              <li class="page-item" :class="{disabled: page===1}">
+                <button class="page-link" @click="prev">Anterior</button>
+              </li>
+              <li class="page-item" v-for="p in pages" :key="p" :class="{active: p===page}">
+                <button class="page-link" @click="go(p)">{{ p }}</button>
+              </li>
+              <li class="page-item" :class="{disabled: page===totalPages}">
+                <button class="page-link" @click="next">Siguiente</button>
+              </li>
+            </ul>
+          </nav>
         </div>
       `
     };


### PR DESCRIPTION
## Summary
- add page number navigation to History and Stats components
- compute page list and add `go()` method

## Testing
- `bazel build //:vertx_hello`

------
https://chatgpt.com/codex/tasks/task_e_6848242a23748323b0dca091368339a7