### PR TITLE
Ordenar numeros verticalmente en generador

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -8,7 +8,7 @@
   <script src="/js/vue-router.global.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <style>
-    .bono-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: .25rem; max-width: 280px; margin: 0 auto; }
+    .bono-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: .25rem; max-width: 280px; margin: 0 auto; }
     .bono-num { border: 1px solid #ccc; border-radius: 4px; padding: .5rem 0; text-align: center; }
     .bono-num.selected { background-color: #0d6efd; color: #fff; }
   </style>
@@ -177,6 +177,24 @@
       data() {
         return { selected: [] };
       },
+      computed: {
+        orderedNumbers() {
+          const cols = [
+            Array.from({ length: 9 }, (_, i) => i + 1),
+            Array.from({ length: 10 }, (_, i) => i + 10),
+            Array.from({ length: 10 }, (_, i) => i + 20),
+            Array.from({ length: 10 }, (_, i) => i + 30),
+            Array.from({ length: 10 }, (_, i) => i + 40)
+          ];
+          const nums = [];
+          for (let r = 0; r < 10; r++) {
+            for (let c = 0; c < cols.length; c++) {
+              if (cols[c][r] !== undefined) nums.push(cols[c][r]);
+            }
+          }
+          return nums;
+        }
+      },
       methods: {
         generate() {
           const nums = Array.from({ length: 49 }, (_, i) => i + 1);
@@ -192,7 +210,7 @@
           <h1 class="mb-4">Generador</h1>
           <router-link to="/" class="btn btn-link p-0 mb-3">Volver</router-link>
           <div class="bono-grid mb-3">
-            <div v-for="n in 49" :key="n" class="bono-num" :class="{selected: selected.includes(n)}">{{ n }}</div>
+            <div v-for="n in orderedNumbers" :key="n" class="bono-num" :class="{selected: selected.includes(n)}">{{ n }}</div>
           </div>
           <button class="btn btn-primary" @click="generate">Generar</button>
         </div>


### PR DESCRIPTION
## Summary
- make number grid 5 columns instead of 7
- generate numbers column-first for realistic bonoloto board

## Testing
- `bazel test //...` *(fails: couldn't complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6848341284a88323a18ffd02638dbc90