### PR TITLE
Add complement number to stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Puedes calcular las estadísticas (pares/impares, reparto por decenas y rachas d
 bazel run //:bonoloto_stats -- path/al/fichero.csv
 ```
 
-La salida es un CSV con las columnas `FECHA`, `N1`-`N6` (números de la combinación ganadora), `EVEN`, `ODD`, `D1`-`D5` (números en las decenas 1‑9, 10‑19, 20‑29, 30‑39 y 40‑49) y `CONSEC`, la longitud máxima de números consecutivos en la combinación.
+La salida es un CSV con las columnas `FECHA`, `N1`‑`N6` (números de la combinación ganadora), `COMP` (complementario), `EVEN`, `ODD`, `D1`‑`D5` (números en las decenas 1‑9, 10‑19, 20‑29, 30‑39 y 40‑49) y `CONSEC`, la longitud máxima de números consecutivos en la combinación.
 

--- a/src/main/java/com/csoft/BonolotoStats.java
+++ b/src/main/java/com/csoft/BonolotoStats.java
@@ -14,14 +14,17 @@ public class BonolotoStats {
         public final String date;
         /** Winning combination numbers */
         public final int[] numbers;
+        /** Complementary number */
+        public final int complement;
         public final int even;
         public final int odd;
         public final int[] tens; // counts of numbers in each tens range
         public final int consecutive; // longest streak of consecutive numbers
 
-        public DrawStat(String date, int[] numbers, int even, int odd, int[] tens, int consecutive) {
+        public DrawStat(String date, int[] numbers, int complement, int even, int odd, int[] tens, int consecutive) {
             this.date = date;
             this.numbers = numbers;
+            this.complement = complement;
             this.even = even;
             this.odd = odd;
             this.tens = tens;
@@ -62,10 +65,11 @@ public class BonolotoStats {
                         tens[4]++;
                     }
                 }
+                int complement = Integer.parseInt(parts[7]);
 
                 Arrays.sort(numbers);
 
-                int maxRun = 1;
+                int maxRun = 0;
                 int currentRun = 1;
                 for (int i = 1; i < numbers.length; i++) {
                     if (numbers[i] == numbers[i - 1] + 1) {
@@ -78,7 +82,7 @@ public class BonolotoStats {
                     }
                 }
 
-                list.add(new DrawStat(parts[0], numbers, even, odd, tens, maxRun));
+                list.add(new DrawStat(parts[0], numbers, complement, even, odd, tens, maxRun));
             }
         }
         return list;
@@ -87,13 +91,14 @@ public class BonolotoStats {
     public static void main(String[] args) throws Exception {
         Path path = Path.of(args.length > 0 ? args[0] : "data/history.csv");
         List<DrawStat> stats = compute(path);
-        System.out.println("FECHA,N1,N2,N3,N4,N5,N6,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC");
+        System.out.println("FECHA,N1,N2,N3,N4,N5,N6,COMP,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC");
         for (DrawStat s : stats) {
             StringBuilder sb = new StringBuilder();
             sb.append(s.date);
             for (int n : s.numbers) {
                 sb.append(',').append(n);
             }
+            sb.append(',').append(s.complement);
             sb.append(',').append(s.even).append(',').append(s.odd)
               .append(',').append(s.tens[0]).append(',').append(s.tens[1])
               .append(',').append(s.tens[2]).append(',').append(s.tens[3])

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -83,13 +83,14 @@ public class MainVerticle extends AbstractVerticle {
                 int end = Math.min(start + size, total);
 
                 StringBuilder sb = new StringBuilder();
-                sb.append("FECHA,N1,N2,N3,N4,N5,N6,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC\n");
+                sb.append("FECHA,N1,N2,N3,N4,N5,N6,COMP,EVEN,ODD,D1,D2,D3,D4,D5,CONSEC\n");
                 for (int i = start; i < end; i++) {
                     var s = stats.get(i);
                     sb.append(s.date);
                     for (int n : s.numbers) {
                         sb.append(',').append(n);
                     }
+                    sb.append(',').append(s.complement);
                     sb.append(',').append(s.even).append(',').append(s.odd)
                       .append(',').append(s.tens[0]).append(',').append(s.tens[1])
                       .append(',').append(s.tens[2]).append(',').append(s.tens[3])


### PR DESCRIPTION
## Summary
- show complementary number in stats API and CLI
- compute consecutive runs starting from zero for draws without streak
- document `COMP` column in README

## Testing
- `bazel build //:vertx_hello`
- `bazel run //:bonoloto_stats -- src/main/resources/webroot/history.csv` *(fails: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_6849262d4fe08323bf37e7f8df3406da