### PR TITLE
Add algorithm console UI

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -11,6 +11,7 @@
     .bono-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: .25rem; max-width: 280px; margin: 0 auto; }
     .bono-num { border: 1px solid #ccc; border-radius: 4px; padding: .5rem 0; text-align: center; }
     .bono-num.selected { background-color: #0d6efd; color: #fff; }
+    .console { background: #000; color: #0f0; font-family: monospace; padding: 1rem; height: 240px; overflow-y: auto; }
   </style>
 </head>
 <body class="bg-light">
@@ -233,6 +234,10 @@
             const res = await fetch('/api/evolve');
             const json = await res.json();
             this.logs = json.steps.concat([`Mejor: ${json.best.join(', ')} puntuación ${json.score}`]);
+            this.$nextTick(() => {
+              const el = this.$refs.console;
+              if (el) el.scrollTop = el.scrollHeight;
+            });
           } catch (e) {
             alert('Error al ejecutar');
           } finally {
@@ -245,9 +250,9 @@
           <h1 class="mb-4">Algoritmo Evolutivo</h1>
           <router-link to="/" class="btn btn-link p-0 mb-3">Volver</router-link>
           <div class="mb-3">
-            <button class="btn btn-primary" @click="run" :disabled="running">Ejecutar</button>
+            <button class="btn btn-primary" @click="run" :disabled="running">Ejecutar algoritmo</button>
           </div>
-          <pre class="text-start">{{ logs.join('\n') }}</pre>
+          <pre class="console" ref="console">{{ logs.join('\n') }}</pre>
         </div>
       `
     };


### PR DESCRIPTION
## Summary
- improve UI on Evolver page: button for executing algorithm and console-style logs

## Testing
- `bazel build //...` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684f41a246988323a95ed94d0fbd5fd5