### PR TITLE
Add configurable generations for evolver

### DIFF
--- a/src/main/java/com/csoft/BonolotoEvolver.java
+++ b/src/main/java/com/csoft/BonolotoEvolver.java
@@ -17,7 +17,7 @@ public class BonolotoEvolver {
     private static final Logger LOGGER = Logger.getLogger(BonolotoEvolver.class.getName());
     private static final int POPULATION_SIZE = 100;
     private static final int ELITE_SIZE = 20;
-    private static final int GENERATIONS = 50;
+    public static final int DEFAULT_GENERATIONS = 50;
 
     public static class EvolutionResult {
         public final List<String> steps;
@@ -197,6 +197,10 @@ public class BonolotoEvolver {
      * along with the best combination found and its score.
      */
     public static EvolutionResult evolve(Path csv) throws IOException {
+        return evolve(csv, DEFAULT_GENERATIONS);
+    }
+
+    public static EvolutionResult evolve(Path csv, int generations) throws IOException {
         Stats tmpStats;
         try {
             tmpStats = loadStats(csv);
@@ -210,7 +214,7 @@ public class BonolotoEvolver {
         double bestScore = Double.NEGATIVE_INFINITY;
         List<String> steps = new ArrayList<>();
 
-        for (int gen = 1; gen <= GENERATIONS; gen++) {
+        for (int gen = 1; gen <= generations; gen++) {
             population.sort((x, y) -> Double.compare(fitness(y, stats), fitness(x, stats)));
             double score = fitness(population.get(0), stats);
             if (score > bestScore) {
@@ -238,6 +242,7 @@ public class BonolotoEvolver {
 
     public static void main(String[] args) throws Exception {
         Path csv = Path.of(args.length > 0 ? args[0] : "data/history.csv");
+        int generations = args.length > 1 ? Integer.parseInt(args[1]) : DEFAULT_GENERATIONS;
         Stats tmpStats;
         try {
             tmpStats = loadStats(csv);
@@ -252,7 +257,7 @@ public class BonolotoEvolver {
         int[] best = null;
         double bestScore = Double.NEGATIVE_INFINITY;
 
-        for (int gen = 1; gen <= GENERATIONS; gen++) {
+        for (int gen = 1; gen <= generations; gen++) {
             population.sort((x, y) -> Double.compare(fitness(y, stats), fitness(x, stats)));
             double score = fitness(population.get(0), stats);
             if (score > bestScore) {

--- a/src/main/java/com/csoft/MainVerticle.java
+++ b/src/main/java/com/csoft/MainVerticle.java
@@ -109,9 +109,14 @@ public class MainVerticle extends AbstractVerticle {
         });
 
         router.get("/api/evolve").handler(ctx -> {
+            int gens = BonolotoEvolver.DEFAULT_GENERATIONS;
+            try {
+                gens = Integer.parseInt(ctx.request().getParam("gens", Integer.toString(BonolotoEvolver.DEFAULT_GENERATIONS)));
+            } catch (NumberFormatException ignore) {}
+            final int generations = gens;
             vertx.<BonolotoEvolver.EvolutionResult>executeBlocking(promise -> {
                 try {
-                    var res = BonolotoEvolver.evolve(Path.of("data/history.csv"));
+                    var res = BonolotoEvolver.evolve(Path.of("data/history.csv"), generations);
                     promise.complete(res);
                 } catch (Exception e) {
                     promise.fail(e);

--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -225,13 +225,13 @@
 
   const Evolver = {
       data() {
-        return { logs: [], running: false };
+        return { logs: [], running: false, generations: 50 };
       },
       methods: {
         async run() {
           this.running = true;
           try {
-            const res = await fetch('/api/evolve');
+            const res = await fetch(`/api/evolve?gens=${this.generations}`);
             const json = await res.json();
             this.logs = json.steps.concat([`Mejor: ${json.best.join(', ')} puntuación ${json.score}`]);
             this.$nextTick(() => {
@@ -260,7 +260,8 @@
                 </p>
               </div>
               <div class="col-md-6 text-center">
-                <div class="mb-3">
+                <div class="mb-3 d-flex gap-2 justify-content-center">
+                  <input type="number" class="form-control" style="max-width:120px;" v-model.number="generations" min="1">
                   <button class="btn btn-primary" @click="run" :disabled="running">Ejecutar algoritmo</button>
                 </div>
                 <pre class="console" ref="console">{{ logs.join('\\n') }}</pre>


### PR DESCRIPTION
## Summary
- allow setting number of generations for the evolutionary algorithm
- expose default generation count constant
- pass generation parameter from the web UI

## Testing
- `bazel build //:vertx_hello`

------
https://chatgpt.com/codex/tasks/task_e_684fbce389ec83239557e43a0f5b986e