### PR TITLE
Add evolutionary algorithm tester

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -243,6 +243,22 @@
           } finally {
             this.running = false;
           }
+        },
+        async test() {
+          this.running = true;
+          try {
+            const res = await fetch(`/api/evolve/test?gens=${this.generations}`);
+            const json = await res.json();
+            this.logs = json.steps.concat([`Total aciertos: ${json.total}`]);
+            this.$nextTick(() => {
+              const el = this.$refs.console;
+              if (el) el.scrollTop = el.scrollHeight;
+            });
+          } catch (e) {
+            alert('Error al ejecutar test');
+          } finally {
+            this.running = false;
+          }
         }
       },
         template: `
@@ -261,8 +277,9 @@
               </div>
               <div class="col-md-6 text-center">
                 <div class="mb-3 d-flex gap-2 justify-content-center">
-                  <input type="number" class="form-control" style="max-width:120px;" v-model.number="generations" min="1">
-                  <button class="btn btn-primary" @click="run" :disabled="running">Ejecutar algoritmo</button>
+                    <input type="number" class="form-control" style="max-width:120px;" v-model.number="generations" min="1">
+                    <button class="btn btn-primary" @click="run" :disabled="running">Ejecutar algoritmo</button>
+                    <button class="btn btn-secondary" @click="test" :disabled="running">Probar histórico</button>
                 </div>
                 <pre class="console" ref="console">{{ logs.join('\\n') }}</pre>
               </div>


### PR DESCRIPTION
## Summary
- add `TestResult` class and `test` method to run the evolutionary algorithm against historical draws
- expose `/api/evolve/test` endpoint to execute the tester
- allow running the tester from the Evolutivo page via new button

## Testing
- `bazel test //:server_test --test_output=errors`

------
https://chatgpt.com/codex/tasks/task_e_68501a2208cc83238f457da40efeca30